### PR TITLE
Set default sort field

### DIFF
--- a/app/Http/Livewire/ContactsTable.php
+++ b/app/Http/Livewire/ContactsTable.php
@@ -10,7 +10,7 @@ class ContactsTable extends Component
     use WithPagination;
 
     public $perPage = 10;
-    public $sortField;
+    public $sortField = 'id';
     public $sortAsc = true;
     public $search = '';
 


### PR DESCRIPTION
Without setting a field as default, eloquent will barf from orderBy().